### PR TITLE
Collecting matches improved

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,14 @@ matching content. By selecting a single item from both views the user is able
 to connect or disconnect the items.
 
 
-_Note:_
-Currently the matches are unfiltered and will display everything which is not a Yeti rig.
+The matching are based on the unique ID which is stored per unique connection in the connection data of the rig.
+
+    Example of connection data:
+        {
+            "connections": ["worldMesh", "inMesh"],
+            "sourceID": "123456789012345:098765",
+            "destinationID: "098765432112345:123456"
+         }
 
 
 ### Dependencies

--- a/mayayetirigmanager/app.py
+++ b/mayayetirigmanager/app.py
@@ -23,7 +23,7 @@ class Window(QtWidgets.QWidget):
     def __init__(self, parent=None):
         QtWidgets.QWidget.__init__(self, parent=parent)
 
-        title = "Yeti Rig Manager 1.0.0 - [%s]" % lib.get_workfile()
+        title = "Yeti Rig Manager 1.1.0 - [%s]" % lib.get_workfile()
         geometry = (800, 400)
 
         self.log = logging.getLogger("Yeti Rig Manager")

--- a/mayayetirigmanager/app.py
+++ b/mayayetirigmanager/app.py
@@ -113,7 +113,7 @@ class Window(QtWidgets.QWidget):
         self.match_view.clear()
 
         rig_items = []
-        match_items = []
+        other_items = []
 
         # Separate based on loader
         for container in lib.get_containers():
@@ -121,7 +121,10 @@ class Window(QtWidgets.QWidget):
             if node["loader"] == "YetiRigLoader":
                 rig_items.append(node)
             else:
-                match_items.append(node)
+                other_items.append(node)
+
+        match_items = lib.get_matches(rig_items, other_items)
+        print(match_items)
 
         self.rig_view.add_items(rig_items)
         self.match_view.add_items(match_items)

--- a/mayayetirigmanager/lib.py
+++ b/mayayetirigmanager/lib.py
@@ -83,6 +83,56 @@ def create_nodes(containers):
     return [create_node(container) for container in containers]
 
 
+def get_source_ids(connections):
+    """Return a list of unique source Ids
+
+    Args:
+        connections(dict): connection data
+
+    Returns:
+        list
+
+    """
+    return list(set(c["sourceID"] for c in connections))
+
+
+def get_matches(rig_items, other_items):
+    """Yields each item which matches for a Yeti rig
+
+    The matching is based on the unique ID which is stored per
+    unique connection in the connection data of the rig.
+
+    Example of connection data:
+        {
+            "connections": ["worldMesh", "inMesh"],
+            "sourceID": "123456789012345:098765",
+            "destinationID: "098765432112345:123456"
+         }
+
+    Args:
+        rig_items (list): list of Yeti rig nodes, list of dicts
+        other_items (list): other items from scene, list of dicts
+
+    Returns:
+        generator object
+
+    """
+
+    # Get connection data per node
+    for node in rig_items:
+        metadata = get_connections(node["representation"])
+        connections = metadata["inputs"]
+
+        # Get the ids of the sources
+        source_ids = get_source_ids(connections)
+
+        # Get matches based on the ids
+        for other in other_items:
+            node_data = other["nodes"]
+            if any(_id for _id in source_ids if _id in node_data):
+                yield other
+
+
 def get_connections(representation_id):
     """Get the metadata file from the data base
 


### PR DESCRIPTION
The issue with the match view was that every loaded asset was listed as a potential match. The user would need to know which asset a match for the Yeti rig.

I have improved the collecting of matches by applying a filter. Each loaded asset and its nodes are being hashed. The connection data of the rig and the node hash of each asset are compared to see if there is any match between the Yeti rig and other asset. If there is a match is will be displayed in the match view.

Improvements:
* Added `get_matches` to lib
* Added `get_source_ids` to lib
* Updated `refresh` method in app